### PR TITLE
wifi testing: frontend updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG APPVERSION
 ARG APPNAME=dashboard
 
 # Label "version" may be incremented upon changing this file.
-LABEL version="1" \
+LABEL version="2" \
       appname="$APPNAME" \
       appversion="$APPVERSION"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9-alpine
+FROM python:3.9-alpine3.14
+# Starting with 3.14 features sqlite3.35 and "returning" clause
 
 # Builds intended for deployment should specify the software
 # version via "APPVERSION".

--- a/manage.py
+++ b/manage.py
@@ -76,7 +76,7 @@ class Management(Local):
         if any(grp.getgrgid(group).gr_name == 'docker' for group in os.getgroups()):
             self.docker = self.local['docker']
         else:
-            self.docker = sudo['-E', 'docker']
+            self.docker = sudo['-E', '--preserve-env=PATH', 'docker']
 
     @localmethod('target', choices=('dash', 'ndt'), nargs='?',
                  help="build target (default: all)")

--- a/src/srv/app/db/sqlite.py
+++ b/src/srv/app/db/sqlite.py
@@ -6,15 +6,21 @@ import app
 
 SQLITE_DEFAULT = app.APP_PATH / 'data.sqlite'
 
-TABLE_STMT_SURVEY = """\
-create table if not exists survey (
-    ts integer primary key default (strftime('%s', 'now')),
-    subj integer
-) without rowid;
-"""
 # NOTE: rowid ommitted to prevent sqlite from substituting a sequential rowid
 # NOTE: for the correct timestamp default;
 # NOTE: (however, there might be better solutions).
+PREPARE_DATABASE = """\
+create table if not exists survey (
+    ts integer primary key default (strftime('%s', 'now')),
+    subj integer not null
+) without rowid;
+
+create table if not exists trial (
+    ts integer primary key default (strftime('%s', 'now')),
+    size integer,
+    period integer
+) without rowid;
+"""
 
 
 class Client(threading.local):
@@ -36,7 +42,7 @@ class Client(threading.local):
 
     def prepare_database(self):
         with self.connect() as conn:
-            conn.execute(TABLE_STMT_SURVEY)
+            conn.executescript(PREPARE_DATABASE)
 
 
 client = Client()

--- a/src/srv/app/handler/trial.py
+++ b/src/srv/app/handler/trial.py
@@ -1,0 +1,180 @@
+import re
+
+from bottle import abort, get, post, put, request, response
+
+from app.db import sqlite as db
+
+
+TRIAL_REPORTING_TIMEOUT = 120
+
+ACTIVE_TRIAL_CONDITION = """\
+size is null and period is null and (strftime('%s', 'now') - ts < ?)\
+"""
+
+RECENT_TRIAL_CONDITION = """\
+size is not null and period is not null and (strftime('%s', 'now') - ts < ?)\
+"""
+
+CAST_TRUE = {'1', 'true', 'on'}
+CAST_FALSE = {'0', 'false', 'off', ''}
+CAST_VALUES = CAST_TRUE | CAST_FALSE
+
+
+def clean_active():
+    active_arg = request.query.active.lower()
+
+    if active_arg not in CAST_VALUES:
+        abort(400, 'Bad request')
+
+    return active_arg in CAST_TRUE
+
+
+def clean_period():
+    if not request.query.period:
+        return None
+
+    period_match = re.fullmatch(r'(\d+)(m|h)?', request.query.period.lower())
+
+    if not period_match:
+        abort(400, 'Bad request')
+
+    (period_value, period_unit) = period_match.groups()
+
+    period_seconds = int(period_value)
+
+    if period_unit == 'm':
+        period_seconds *= 60
+    elif period_unit == 'h':
+        period_seconds *= 3600
+
+    return period_seconds
+
+
+def clean_limit():
+    if not request.query.limit:
+        return None
+
+    try:
+        return int(request.query.limit)
+    except ValueError:
+        abort(400, 'Bad request')
+
+
+def build_where_clause():
+    where = ''
+    args = []
+
+    if clean_active():
+        where = f'where ({ACTIVE_TRIAL_CONDITION})'
+        args.append(TRIAL_REPORTING_TIMEOUT)
+
+    if (period := clean_period()) is not None:
+        where += ' or ' if where else 'where '
+        where += f'({RECENT_TRIAL_CONDITION})'
+        args.append(period)
+
+    return (where, args)
+
+
+@get('/dashboard/trial/')
+def list_trials():
+    (where, args) = build_where_clause()
+
+    limit = '' if (limit_value := clean_limit()) is None else f'limit {limit_value}'
+
+    with db.client.connect() as conn:
+        cursor = conn.execute(f"select * from trial {where} order by ts desc {limit}", args)
+
+        results = [
+            dict(zip(cursor.description, row))
+            for row in cursor
+        ]
+
+        result_count = cursor.rowcount
+
+    return {
+        'selected': results,
+        'count': result_count,
+    }
+
+
+@get('/dashboard/trial/stats')
+def stat_trials():
+    with db.client.connect() as conn:
+        (total_count,) = conn.execute("""\
+            select count(1) from trial
+            where size is not null and period is not null
+        """).fetchone()
+
+        where = "where bucket between 2 and 9" if total_count > 8 else ""
+
+        (stat_mean, stat_count) = conn.execute(f"""\
+            select avg(rate),
+                   count(1)
+
+            from (
+                select rate,
+                       ntile(10) over (order by rate) as bucket
+
+                from (
+                    select 1000000.0 * size / period as rate from trial
+                    where size is not null and period is not null
+                )
+            )
+
+            {where}
+        """).fetchone()
+
+    return {
+        'total_count': total_count,
+        'stat_count': stat_count,
+        'stat_mean': stat_mean,
+    }
+
+
+@post('/dashboard/trial/')
+def create_trial():
+    if request.forms:
+        raise NotImplementedError
+
+    (where, args) = build_where_clause()
+
+    if where:
+        query = f"""\
+            insert into trial (ts)
+
+            select * from (values (strftime('%s', 'now')))
+            where not exists (select 1 from trial {where} limit 1)
+
+            returning ts
+        """
+    else:
+        query = "insert into trial default values returning ts"
+
+    with db.client.connect() as conn:
+        cursor = conn.execute(query, args)
+
+        (ts,) = cursor.fetchone() or (None,)
+
+    response.status = 409 if ts is None else 201
+
+    return {
+        'inserted': None if ts is None else {'ts': ts},
+    }
+
+
+@put('/dashboard/trial/<ts:int>')
+def upsert_trial(ts):
+    try:
+        values = [int(arg) for arg in (request.forms.size,
+                                       request.forms.period)]
+    except ValueError:
+        abort(400, 'Bad request')
+
+    with db.client.connect() as conn:
+        conn.execute("""\
+            insert into trial values (?, ?, ?)
+            on conflict (ts) do update set size=excluded.size, period=excluded.period
+        """, [ts] + values)
+
+    response.status = 204

--- a/src/srv/app/static/asset/ndt7-run-dash.js
+++ b/src/srv/app/static/asset/ndt7-run-dash.js
@@ -1,74 +1,142 @@
 /* jshint esversion: 6, asi: true */
 /* globals ndt7core */
 
-function update_values(info, tag) {
+function update_values (info, tag, complete) {
+  if (!info) {
+    if (complete) {
+      const failure = document.getElementById('wifi-failure');
+
+      failure.classList.remove('d-none');
+      post_loading(failure.parentElement);
+    }
+
+    return;
+  }
+
   const elapsed = info.ElapsedTime / 1e06     /* second */
   let speed = info.NumBytes / elapsed         /* B/s    */
   speed *= 8                                     /* bit/s  */
   speed /= 1e06                                  /* Mbit/s */
   speed = speed.toFixed(1)
 
-  const dl= document.getElementById("ookla_dl")
-  dl_value = parseFloat(dl.innerHTML)
+  const el = document.getElementById("wifi_bw"),
+        dl = document.getElementById("ookla_dl"),
+        dl_value = parseFloat(dl.innerHTML);
 
-  const el = document.getElementById("wifi_bw")
+  el.innerHTML = speed;
 
-  el.innerHTML = speed
-
-  pardiv = el.parentElement
+  const pardiv = el.parentElement
   pardiv.classList.remove("bad")
   pardiv.classList.remove("ok")
   pardiv.classList.remove("good")
 
-  const txt1 = document.getElementById("text_wifi_interp1")
-  const txt2 = document.getElementById("text_wifi_interp2")
+  const [op, desc, label] = compare_speeds(speed, dl_value);
+  pardiv.classList.add(label);
 
-  if      (speed < dl_value * 0.75) {
-    pardiv.classList.add("bad");
-    txt1.innerHTML = "less than"
-    txt2.innerHTML = "bad"
-  } else if (speed > dl_value * 1.25) {
-    pardiv.classList.add("good");
-    txt1.innerHTML = "greater than"
-    txt2.innerHTML = "good"
-  } else {
-    pardiv.classList.add("ok");
-    txt1.innerHTML = "similar to"
-    txt2.innerHTML = "not great"
+  if (complete) {
+    const txt1 = document.getElementById("text_wifi_interp1")
+    const txt2 = document.getElementById("text_wifi_interp2")
+    const paragraph = txt1.parentElement
+    const section = paragraph.parentElement
+
+    txt1.innerHTML = op;
+    txt2.innerHTML = desc;
+
+    paragraph.classList.remove('d-none');
+    post_loading(section);
   }
-
 }
 
-function run_ndt(testName, callback) {
+function post_loading (elem) {
+  elem.querySelectorAll('.loading').forEach(
+    function (elem) {
+        elem.classList.remove('loading');
+        elem.classList.add('loading-done');
+    }
+  );
+}
+
+function compare_speeds(a, b) {
+  if      (a < b * 0.75) {
+    return ['less than', 'bad', 'bad'];
+  } else if (a > b * 1.25) {
+    return ["greater than", "good", "good"];
+  } else {
+    return ["similar to", "not great", "ok"];
+  }
+}
+
+function run_ndt (testName, callback) {
+  let lastMeasurement = null;
+
+  function recordMeasurement (origin, results) {
+    if (origin === 'client') {
+      lastMeasurement = results;
+    }
+  }
+
   /*
    * HTTPS would be nice -- but disabling for now as user must manually accept certificate!
    */
-  ndt7core.run("http://netrics.local:8888/ndt7.html", testName, function(ev, val) {
-    // console.log(ev, val)
-    if (ev === 'complete') {
+  // FIXME: can't assume netrics.local!
+  ndt7core.run('http://netrics.local:8888/ndt7.html', testName, function (eventName, values) {
+    // DEBUG: console.debug(eventName, values)
+
+    const origin = values.Origin,
+          results = values.AppInfo || null;
+
+    if (eventName === 'starting') {
+      console.debug('LAN bandwidth test started');
+    } else if (eventName === 'measurement') {
+      recordMeasurement(origin, results);
+      update_values(lastMeasurement, testName);
+    } else if (eventName === 'complete') {
+      update_values(lastMeasurement, testName, true);
+
       if (callback !== undefined) {
-        callback()
+        callback(lastMeasurement, testName);
       }
-      console.log("LAN bandwidth test complete")
-      return
+
+      console.debug('LAN bandwidth test complete');
     }
-    if (ev === 'measurement' && val.AppInfo !== undefined &&
-        val.Origin === 'client') {
-      update_values(val.AppInfo, testName)
-    }
+  });
+}
+
+function send_download (callback, measurement, testName) {
+  if (measurement && Number.isInteger(this.ts)) {
+    $.ajax(`trial/${this.ts}`, {
+      method: 'PUT',
+      data: {
+        size: measurement.NumBytes,
+        period: measurement.ElapsedTime.toFixed()
+      }
+    });
+  } else {
+    console.error('bad trial object %o or results %o', this, measurement);
+  }
+
+  if (callback !== undefined) {
+    callback(measurement, testName);
+  }
+}
+
+function run_download (callback) {
+  $.post('trial/?active=on', null, 'json')
+  .done(result => {
+    run_ndt('download', send_download.bind(result.inserted, callback))
   })
+  .fail(() => {
+    console.error('LAN bandwidth test could not be started');
+    update_values(null, 'download', true);
+  });
 }
 
-function run_download(callback) {
-  run_ndt('download', callback)
-}
-
-function run_upload(callback) {
+function run_upload (callback) {
   run_ndt('upload', callback)
 }
 
-function run_both() {
-  run_download(function() { run_upload(); })
+function run_both () {
+  run_download(() => run_upload())
 }
 
 run_download()

--- a/src/srv/app/static/asset/site.css
+++ b/src/srv/app/static/asset/site.css
@@ -63,7 +63,7 @@ ul.dropdown-menu>li {
   transition: max-height 0.2s ease-out;
 }
 
-.learn_more > p { 
+.learn_more > p {
   font-size: 18px;
 }
 
@@ -180,4 +180,33 @@ ul.dropdown-menu>li {
 /* fix bootstrap missing !important */
 .collapse:not(.show) {
   display: none !important;
+}
+
+.loading:after, .loading-done:after {
+  overflow: hidden;
+  display: inline-block;
+  vertical-align: bottom;
+  content: "\2026"; /* ascii code for the ellipsis character */
+}
+
+.loading:after {
+  -webkit-animation: ellipsis steps(4,end) 900ms infinite;
+  animation: ellipsis steps(4,end) 900ms infinite;
+  width: 0px;
+}
+
+@keyframes ellipsis {
+  to {
+    width: 1.5em;
+  }
+}
+
+@-webkit-keyframes ellipsis {
+  to {
+    width: 1.5em;
+  }
+}
+
+.wifi-stats {
+  display: none;
 }

--- a/src/srv/app/static/index.html
+++ b/src/srv/app/static/index.html
@@ -13,7 +13,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.1/dist/umd/popper.min.js" integrity="sha384-SR1sx49pcuLnqZUnnPwx6FCym0wLsk5JZuNx2bPPENzswTNFaQU1RDvt3wT4gWFG" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.min.js" integrity="sha384-j0CNLUeiqtyaRmlzUHCPZ+Gy5fQu0dQ6eZ/xAww941Ai1SxSY+0EQqNXNE6DZiVc" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="https://code.jquery.com/jquery-1.7.1.min.js"></script>
+  <script type="text/javascript" src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
   <script src='https://cdn.plot.ly/plotly-latest.min.js'></script>
 
@@ -53,9 +53,9 @@
 	    <span>How is your<br>Internet?</span>
           </button>
           <ul class="dropdown-menu" aria-labelledby="subj_button">
-            <li><a class="dropdown-item" href="#" onclick=send_subjective('good');>Good</a></li>
-            <li><a class="dropdown-item" href="#" onclick=send_subjective('slow');>Slow</a></li>
-            <li><a class="dropdown-item" href="#" onclick=send_subjective('unusable');>Unusable</a></li>
+            <li><a class="dropdown-item" href="#" onclick="subjective.send('good')">Good</a></li>
+            <li><a class="dropdown-item" href="#" onclick="subjective.send('slow')">Slow</a></li>
+            <li><a class="dropdown-item" href="#" onclick="subjective.send('unusable')">Unusable</a></li>
           </ul>
 	  <div id="survey_thanks"></div>
 	</div>
@@ -78,6 +78,8 @@
 	    in "Megabits per second" (Mbps).
 	  This affects how many people in your household can
 	    can simultaneously use applications like Netflix or Zoom.
+        </p>
+        <p>
 	  Your current bandwidth of 
 	    <span id=text_ookla_dl>25</span>/<span id=text_ookla_ul>3</span>&nbsp;Mbps
 	    <span id=text_bw_interp>is similar to other </span> households in Chicago.
@@ -138,12 +140,21 @@
 	    If your Wi-Fi bandwidth is less than that of your wired connection,
 	      you won't be able to use the full bandwidth that
 	      you pay for from your ISP.
-	    Your Wi-Fi bandwidth is <span id=text_wifi_interp1>greater than</span> that of the conection from your ISP:
-	      that's <span id=text_wifi_interp2>good</span>.
           </p>
-	  <p>
-	    This test runs automatically, within your network, when you load this page.
+
+          <p id="wifi-info" class="wifi-stats">
+          </p>
+
+	  <p class="loading">
+        A test of your Wi-Fi <span class="wifi-stats">also</span> runs automatically, within your network, when you load this page
 	  </p>
+	  <p class="d-none">
+	    &hellip; Your Wi-Fi bandwidth was <span id=text_wifi_interp1>greater than</span> that of the conection from your ISP:
+	      that's <span id=text_wifi_interp2>good</span>.
+	  </p>
+      <p id="wifi-failure" class="d-none">
+        <strong>Whoops.</strong> Something went wrong. Try again in a few moments.
+      </p>
 
 	  <p class=extras>
 	    <span onclick="toggle(this, 'wifi_more')" class=toggle_button id=bw_more_tog>+ Learn more</span> <br>
@@ -193,6 +204,8 @@
 	      to reach a service on the Internet, like Wikipedia or YouTube.
 	    This is measured in milliseconds &mdash;
 	      thousandths of a second.
+          </p>
+          <p>
 	    Your network latency to Google is 
 	      <span id=text_latency_interp>similar to other</span> households in Chicago.
           </p>


### PR DESCRIPTION
Splitting out this incremental work &ndash; on the web server & web page &ndash; from the rest, so as to get the changes out to people, (for testing, for use, *etc*.).

### local dashboard frontend support for wifi test lock & results record
    
* frontend now requests wifi test record & lock prior to initiating wifi
    download test, and reports results of test back to server for record.
* historical stats of above test results reported to user
* reporting of active test's status is now more graceful -- qualitative
    label, etc. only applied once final results are in
* test failures are reported to user (failure to acquire lock, name
    resolution error, etc.)
* (plus trivial aesthetic changes in frontend and frontend code)

### management command support

&hellip; for user not in "docker" group and for development version tags