### PR TITLE
make extension installation status notifications dismissable

### DIFF
--- a/src/srv/app/static/asset/data-mgmt.js
+++ b/src/srv/app/static/asset/data-mgmt.js
@@ -257,6 +257,7 @@ const extWatcher = {
   enabled: true,
   installed: null,
   extDataType: 'ndt7ext',
+  storageKeys: ['notInstalledDimiss', 'installedDismiss'],
   listen: function (event) {
     // We only accept messages from ourselves
     if (event.source !== window) return;
@@ -281,6 +282,8 @@ const extWatcher = {
     }
   },
   updateView: function () {
+    if (this.getDismiss()) return;
+
     var notice = $('.extension-notice'),
         noticeMissing = $('.extension-notice-missing'),
         noticeInstalled = $('.extension-notice-installed');
@@ -292,6 +295,34 @@ const extWatcher = {
     noticeMissing.collapse(this.installed ? 'hide' : 'show');
 
     notice.collapse('show');
+
+    notice.click(this, this._dismiss);
+  },
+  _dismiss: function (event) {
+    // collapse notice IFF it wasn't the installation link that they clicked
+    if (! event.target.href) {
+      $(this).collapse('hide')
+
+      // persist their election to dismiss this notice
+      event.data.setDismiss()
+    }
+  },
+  getDismissKey: function () {
+      const keyIndex = Number(this.installed)
+
+      return this.storageKeys[keyIndex]
+  },
+  getDismiss: function () {
+      const storageKey = this.getDismissKey()
+
+      return storageKey && localStorage.getItem(storageKey)
+  },
+  setDismiss: function () {
+      const storageKey = this.getDismissKey()
+
+      if (storageKey) {
+        localStorage.setItem(storageKey, '1')
+      }
   },
   isGoogleChrome: function () {
     var winNav = window.navigator,

--- a/src/srv/app/static/asset/site.css
+++ b/src/srv/app/static/asset/site.css
@@ -47,6 +47,7 @@ ul.dropdown-menu>li {
 }
 
 .extension-notice {
+    cursor: pointer;
     position: relative;
     padding: 1rem 1rem;
     margin-bottom: 0;
@@ -55,13 +56,19 @@ ul.dropdown-menu>li {
 }
 .extension-notice-success {
     color: #055160;
-    background-color: #cff4fc;
+    background-color: rgba(207, 244, 252, 1);
     border-color: #b6effb;
+}
+.extension-notice-success:hover {
+    background-color: rgba(207, 244, 252, 0.75);
 }
 .extension-notice-failure {
     color: #664d03;
-    background-color: #fff3cd;
+    background-color: rgba(255, 243, 205, 1);
     border-color: #ffecb5;
+}
+.extension-notice-failure:hover {
+    background-color: rgba(255, 243, 205, 0.75);
 }
 
 .extension-notice p {

--- a/src/srv/app/static/index.html
+++ b/src/srv/app/static/index.html
@@ -34,7 +34,7 @@
 
     <div class="d-flex">
       <div class="col-2"></div>
-      <div class="col-8 extension-notice collapse d-flex justify-content-between">
+      <div class="col-8 extension-notice collapse d-flex justify-content-between" title="Click to dismiss…">
         <p>
           Home Network Speed Test browser extension
 
@@ -55,6 +55,7 @@
           class="btn btn-primary extension-notice-missing collapse"
           role="button"
           href="https://chrome.google.com/webstore/detail/home-network-speed-test/igapnjodianlpbbnighbogichpajdneb"
+          title="Click to install…"
         >
           Install <i class="bi bi-gear-fill"></i>
         </a>


### PR DESCRIPTION
Installation status notifications are now clickable (with an on-hover `title`: "Click to dismiss…"). Clicking on the notification (rather than on say its "Install" button) will dismiss the notification.

Notification will note its dismissal in localStorage -- depending on its type (success/failure) -- and will not show itself again.

(Subsequent notifications of a different type *will* be shown.)