### PR TITLE
Network bandwidth tests plot

### DIFF
--- a/src/srv/app/handler/trial.py
+++ b/src/srv/app/handler/trial.py
@@ -114,7 +114,7 @@ def list_trials():
 
 @get('/dashboard/trial/stats')
 def stat_trials():
-    recent_limit = 5 if (limit_value := clean_limit()) is None else limit_value
+    recent_limit = 10 if (limit_value := clean_limit()) is None else limit_value
     if not 0 <= recent_limit <= 1000:
         abort(400, 'Bad request')
 

--- a/src/srv/app/static/asset/data-mgmt.js
+++ b/src/srv/app/static/asset/data-mgmt.js
@@ -248,7 +248,7 @@ function update_trial_stats (wifi_trial, isp_dl) {
   const success_rate = wifi_trial.success_count === null ? null : (100 * wifi_trial.success_count / wifi_trial.total_count).toFixed(0),
         failure_rate = success_rate === null ? null : 100 - success_rate,
         failure_count = wifi_trial.success_count === null ? null : wifi_trial.total_count - wifi_trial.success_count,
-        rate_stable = wifi_trial.stat_stdev < 0.15 * wifi_trial.last_rate,
+        rate_stable = wifi_trial.stat_stdev < 0.15 * wifi_trial.recent_rates[0].speed,
         mbaud = (wifi_trial.stat_mean_win * 8 / 1e06).toFixed(0),
         [op, desc, label] = ndt7view.compare_speeds(mbaud, isp_dl),
         info = $('#wifi-info');

--- a/src/srv/app/static/index.html
+++ b/src/srv/app/static/index.html
@@ -219,6 +219,10 @@
 	    </p>
 	  </div>
 
+	  <p class=extras>
+	    <span data-toggle="wifi_plot" data-toggle-defer="plots-trials" class="toggle-button toggle-button-deferred" id="wifi_plot_tog">+ Recent network bandwidth tests</span>
+	  </p>
+	  <div id="wifi_plot" class="learn_more"></div>
 	</div>
 
 	<div class="col-3">


### PR DESCRIPTION
Display last 10 network download test results as horizontal bar chart.

The most recent ISP bandwidth is presented as a threshold line.

Tests are keyed by their test number rather than timestamp to avoid association with time and to easily ensure consistent spacing and legible presentation. (Chart is horizontal for legibility as well.)

See #4 

---

![image](https://user-images.githubusercontent.com/530998/138321791-932c5e88-c0d6-4709-b179-8838ae3e1adf.png)
