### PR TITLE
docker-compose configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,18 +24,18 @@ ENV APP_NAME="$APPNAME"                               \
 
 # Create core app user, group and directories.
 RUN <<-EOF
-    set -ex
+	set -ex
 
-    addgroup -S "$APPNAME"
-    adduser --no-create-home --disabled-password "$APPNAME" --ingroup "$APPNAME"
+	addgroup -S "$APPNAME"
+	adduser --no-create-home --disabled-password "$APPNAME" --ingroup "$APPNAME"
 
-    mkdir -p /usr/src/"$APPNAME"
-    chown "$APPNAME" /usr/src/"$APPNAME"
-    chmod ug+rwx /usr/src/"$APPNAME"
+	mkdir -p /usr/src/"$APPNAME"
+	chown "$APPNAME" /usr/src/"$APPNAME"
+	chmod ug+rwx /usr/src/"$APPNAME"
 
-    mkdir -p /var/lib/"$APPNAME"
-    chown "$APPNAME" /var/lib/"$APPNAME"
-    chmod ug+rwx /var/lib/"$APPNAME"
+	mkdir -p /var/lib/"$APPNAME"
+	chown "$APPNAME" /var/lib/"$APPNAME"
+	chmod ug+rwx /var/lib/"$APPNAME"
 EOF
 
 WORKDIR /usr/src/"$APPNAME"
@@ -59,15 +59,26 @@ ENV FATE_PREFIX_PROFILE="system"
 COPY etc/fate /etc/fate
 
 RUN <<-EOF
-    set -ex
+	set -ex
 
-    python -m venv /usr/local/lib/fate
+	python -m venv /usr/local/lib/fate
 
-    /usr/local/lib/fate/bin/pip install --no-cache-dir fate-scheduler=="$FATEVERSION"
+	/usr/local/lib/fate/bin/pip install --no-cache-dir fate-scheduler=="$FATEVERSION"
 
-    # (note: busybox ln doesn't appear to support -t as expected)
-    ln -s /usr/local/lib/fate/bin/fate* /usr/local/bin
+	# (note: busybox ln doesn't appear to support -t as expected)
+	ln -s /usr/local/lib/fate/bin/fate* /usr/local/bin
 EOF
+
+# Create conventional interface convenience scripts.
+COPY --chmod=775 <<-dashboard-serve /usr/local/bin/"${APPNAME}"-serve
+	#!/bin/sh
+	exec python -m app
+dashboard-serve
+
+COPY --chmod=775 <<-dashboard-extract /usr/local/bin/"${APPNAME}"-extract
+	#!/bin/sh
+	exec fated --foreground
+dashboard-extract
 
 USER "$APPNAME"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM python:3.9-alpine3.17
 # Starting with 3.14 features sqlite3.35 and "returning" clause
 
@@ -5,30 +6,37 @@ FROM python:3.9-alpine3.17
 # version via "APPVERSION".
 ARG APPVERSION
 ARG APPNAME=dashboard
+ARG FATEVERSION=0.1.0rc2
 
 # Label "version" may be incremented upon changing this file.
-LABEL version="3" \
-      appname="$APPNAME" \
-      appversion="$APPVERSION"
+LABEL version="3"                \
+      appname="$APPNAME"         \
+      appversion="$APPVERSION"   \
+      fateversion="$FATEVERSION"
 
 # Configure core app environment.
-ENV APP_NAME="$APPNAME" \
-    APP_VERSION="$APPVERSION" \
-    APP_HOST="0.0.0.0" \
+ENV APP_NAME="$APPNAME"                               \
+    APP_VERSION="$APPVERSION"                         \
+    APP_HOST="0.0.0.0"                                \
     APP_DATABASE="file:/var/lib/$APPNAME/data.sqlite" \
-    PYTHONPATH=/usr/src/"$APPNAME"/srv \
+    PYTHONPATH=/usr/src/"$APPNAME"/srv                \
     PYTHONUNBUFFERED=1
 
 # Create core app user, group and directories.
-RUN set -ex && \
-    addgroup -S "$APPNAME" && \
-    adduser --no-create-home --disabled-password "$APPNAME" --ingroup "$APPNAME" && \
-    mkdir -p /usr/src/"$APPNAME" && \
-    chown "$APPNAME" /usr/src/"$APPNAME" && \
-    chmod ug+rwx /usr/src/"$APPNAME" && \
-    mkdir -p /var/lib/"$APPNAME" && \
-    chown "$APPNAME" /var/lib/"$APPNAME" && \
+RUN <<-EOF
+    set -ex
+
+    addgroup -S "$APPNAME"
+    adduser --no-create-home --disabled-password "$APPNAME" --ingroup "$APPNAME"
+
+    mkdir -p /usr/src/"$APPNAME"
+    chown "$APPNAME" /usr/src/"$APPNAME"
+    chmod ug+rwx /usr/src/"$APPNAME"
+
+    mkdir -p /var/lib/"$APPNAME"
+    chown "$APPNAME" /var/lib/"$APPNAME"
     chmod ug+rwx /var/lib/"$APPNAME"
+EOF
 
 WORKDIR /usr/src/"$APPNAME"
 
@@ -50,11 +58,16 @@ ENV FATE_PREFIX_PROFILE="system"
 
 COPY etc/fate /etc/fate
 
-# (note: busybox ln doesn't appear to support -t as expected)
-RUN set -ex \
-    ; python -m venv /usr/local/lib/fate \
-    ; /usr/local/lib/fate/bin/pip install --no-cache-dir fate-scheduler==0.1.0rc2 \
-    ; ln -s /usr/local/lib/fate/bin/fate* /usr/local/bin
+RUN <<-EOF
+    set -ex
+
+    python -m venv /usr/local/lib/fate
+
+    /usr/local/lib/fate/bin/pip install --no-cache-dir fate-scheduler=="$FATEVERSION"
+
+    # (note: busybox ln doesn't appear to support -t as expected)
+    ln -s /usr/local/lib/fate/bin/fate* /usr/local/bin
+EOF
 
 USER "$APPNAME"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
 
     tmpfs:
       - /run
+      - /tmp
 
     volumes:
       - web-data:/var/lib/dashboard:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ volumes:
   netrics-measurements-data:
     driver: local
     driver_opts:
+      type: none
       device: "${NETRICS_MEASUREMENTS_PATH:-/var/nm}"
       o: bind
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,139 @@
+services:
+  ndt:
+    container_name: ndt-server
+
+    image: "chicagocdac/ndt-server-full:${NDT_SERVER_VERSION:-latest}"
+
+    command: [
+      "-cert", "/cert/cert.pem",
+      "-key", "/cert/key.pem",
+      "-datadir", "/data",
+      "-ndt7_addr", ":4444",
+      "-ndt7_addr_cleartext", ":8888",
+    ]
+
+    logging:
+      driver: local
+
+    cap_drop:
+      - ALL
+
+    ports:
+      - target: 4444
+        published: "${NDT_SERVER_PORT_CRYPT:-4444}"
+        protocol: tcp
+        mode: bridge
+      - target: 8888
+        published: "${NDT_SERVER_PORT_CLEAR:-8888}"
+        protocol: tcp
+        mode: bridge
+
+    read_only: true
+
+    restart: always
+
+    volumes:
+      - ndt-server-cert:/cert:rw
+      - ndt-server-data:/data:rw
+
+  web:
+    container_name: netrics-dashboard
+
+    image: "chicagocdac/netrics-dashboard:${NETRICS_DASHBOARD_VERSION:-latest}"
+
+    logging:
+      driver: local
+
+    ports:
+      - target: 8080
+        published: "${NETRICS_DASHBOARD_PORT:-80}"
+        protocol: tcp
+        mode: bridge
+
+    read_only: true
+
+    restart: always
+
+    volumes:
+      - netrics-dashboard-data:/var/lib/dashboard:rw
+      - netrics-measurements-data:/var/lib/nm:ro
+
+    environment:
+      DATAFILE_PENDING: "/var/lib/nm/nm-exp-active-netrics/upload/pending/${NETRICS_TOPIC:-default}/json/"
+      DATAFILE_ARCHIVE: "/var/lib/nm/nm-exp-active-netrics/upload/archive/${NETRICS_TOPIC:-default}/json/"
+
+  etl:
+    container_name: netrics-dashboard-etl
+
+    image: "chicagocdac/netrics-dashboard:${NETRICS_DASHBOARD_VERSION:-latest}"
+
+    user: root
+
+    command:
+      - fated
+      - --foreground
+
+    logging:
+      driver: local
+
+    read_only: true
+
+    restart: always
+
+    tmpfs:
+      - /run
+
+    volumes:
+      - netrics-dashboard-data:/var/lib/dashboard:rw
+      - netrics-measurements-data:/var/lib/nm:rw
+      - ndt-server-data:/var/lib/ndt-server/data:rw
+      - netrics-dashboard-etl:/var/lib/fate:rw
+
+    environment:
+      EXTRACT_DIR: "/var/lib/nm/nm-exp-local-dashboard/upload/"
+      NDT7_DIR: "/var/lib/ndt-server/data/ndt7/"
+
+volumes:
+  #
+  # netrics measurement data
+  #
+  # below we assume that netrics measurements data are managed *elsewhere*.
+  #
+  # rather than repeat a Docker bind mount for each service above, we define a
+  # single volume, but which is really just a Linux bind mount from *wherever*
+  # netrics data are and into the Docker daemon's path.
+  #
+  # should the netrics measurements data volume instead be managed by this file,
+  # then this should perhaps change.
+  #
+  netrics-measurements-data:
+    driver: local
+    driver_opts:
+      device: "${NETRICS_MEASUREMENTS_PATH:-/var/nm}"
+      o: bind
+
+  #
+  # netrics dashboard data
+  #
+  # rather than mandate that dashboard data is stored at a particular path on
+  # the host system -- such as /var/lib/netrics-dashboard -- below we ask the
+  # Docker daemon to manage this volume (somewhere under its path on the host).
+  #
+  # YMMV.
+  #
+  netrics-dashboard-data:
+
+  #
+  # ndt certificate files
+  #
+  ndt-server-cert:
+
+  #
+  # ndt data
+  #
+  ndt-server-data:
+
+  #
+  # etl manager state data
+  #
+  netrics-dashboard-etl:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 services:
   ndt:
-    container_name: ndt-server
-
     image: "chicagocdac/ndt-server-full:${NDT_SERVER_VERSION:-latest}"
 
     command: [
@@ -33,12 +31,10 @@ services:
     restart: always
 
     volumes:
-      - ndt-server-cert:/cert:rw
-      - ndt-server-data:/data:rw
+      - ndt-cert:/cert:rw
+      - ndt-data:/data:rw
 
   web:
-    container_name: netrics-dashboard
-
     image: "chicagocdac/netrics-dashboard:${NETRICS_DASHBOARD_VERSION:-latest}"
 
     logging:
@@ -55,23 +51,19 @@ services:
     restart: always
 
     volumes:
-      - netrics-dashboard-data:/var/lib/dashboard:rw
-      - netrics-measurements-data:/var/lib/nm:ro
+      - web-data:/var/lib/dashboard:rw
+      - measurements-data:/var/lib/nm:ro
 
     environment:
       DATAFILE_PENDING: "/var/lib/nm/nm-exp-active-netrics/upload/pending/${NETRICS_TOPIC:-default}/json/"
       DATAFILE_ARCHIVE: "/var/lib/nm/nm-exp-active-netrics/upload/archive/${NETRICS_TOPIC:-default}/json/"
 
   etl:
-    container_name: netrics-dashboard-etl
-
     image: "chicagocdac/netrics-dashboard:${NETRICS_DASHBOARD_VERSION:-latest}"
 
     user: root
 
-    command:
-      - fated
-      - --foreground
+    command: dashboard-extract
 
     logging:
       driver: local
@@ -84,10 +76,10 @@ services:
       - /run
 
     volumes:
-      - netrics-dashboard-data:/var/lib/dashboard:rw
-      - netrics-measurements-data:/var/lib/nm:rw
-      - ndt-server-data:/var/lib/ndt-server/data:rw
-      - netrics-dashboard-etl:/var/lib/fate:rw
+      - web-data:/var/lib/dashboard:rw
+      - measurements-data:/var/lib/nm:rw
+      - ndt-data:/var/lib/ndt-server/data:rw
+      - etl-state:/var/lib/fate:rw
 
     environment:
       EXTRACT_DIR: "/var/lib/nm/nm-exp-local-dashboard/upload/"
@@ -106,7 +98,7 @@ volumes:
   # should the netrics measurements data volume instead be managed by this file,
   # then this should perhaps change.
   #
-  netrics-measurements-data:
+  measurements-data:
     driver: local
     driver_opts:
       type: none
@@ -122,19 +114,19 @@ volumes:
   #
   # YMMV.
   #
-  netrics-dashboard-data:
+  web-data:
 
   #
   # ndt certificate files
   #
-  ndt-server-cert:
+  ndt-cert:
 
   #
   # ndt data
   #
-  ndt-server-data:
+  ndt-data:
 
   #
   # etl manager state data
   #
-  netrics-dashboard-etl:
+  etl-state:

--- a/etc/fate/tasks.toml
+++ b/etc/fate/tasks.toml
@@ -1,0 +1,22 @@
+[extract-db]
+exec = [
+  "python",
+  "-m",
+  "app.cmd",
+  "backupdb",
+  "--compress",
+  "{{ env.EXTRACT_DIR }}",
+]
+if = "env.EXTRACT_DIR"
+schedule = "@midnight"
+
+[extract-ndt7]
+shell = '''
+  # move ndt7 data files into place
+  find "$NDT7_DIR" -type f \! -empty -print0 | xargs -0 -r mv -t "$EXTRACT_DIR/pending/ndt7/json/"
+
+  # clean up empty source directories
+  find "$NDT7_DIR" -mindepth 1 -type d -empty -delete
+'''
+if = "env.EXTRACT_DIR and env.NDT7_DIR"
+schedule = "@midnight"

--- a/image/ndt/Dockerfile
+++ b/image/ndt/Dockerfile
@@ -1,4 +1,4 @@
-FROM measurementlab/ndt-server:v0.20.17
+FROM chicagocdac/ndt-server:v0.20.17
 
 RUN apk add --no-cache \
     openssl            \

--- a/image/ndt/Dockerfile
+++ b/image/ndt/Dockerfile
@@ -1,0 +1,11 @@
+FROM measurementlab/ndt-server:v0.20.17
+
+RUN apk add --no-cache \
+    openssl            \
+    python3
+
+COPY bootstrap.py /ndt-bootstrap
+
+RUN chmod 744 /ndt-bootstrap
+
+ENTRYPOINT ["/ndt-bootstrap"]

--- a/image/ndt/bootstrap.py
+++ b/image/ndt/bootstrap.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""NDT server launcher ensuring SSL certificate generation."""
+import argparse
+import pathlib
+import subprocess
+import sys
+
+
+def make_parser():
+    parser = argparse.ArgumentParser(
+        description="ndt-server entrypoint",
+        usage="%(prog)s [-h] [-cert PATH] [-key PATH] "
+              "[ ... add'l ndt-server options ... ]",
+    )
+
+    parser.add_argument(
+        '-cert',
+        metavar='PATH',
+        type=pathlib.Path,
+        help="path to certificate file",
+    )
+    parser.add_argument(
+        '-key',
+        metavar='PATH',
+        type=pathlib.Path,
+        help="path to key file",
+    )
+
+    return parser
+
+
+def parse_args(parser, args=None):
+    (boot_args, _ndt_args) = parser.parse_known_args(args)
+    return boot_args
+
+
+def generate_certificate(cert, key):
+    if not cert or not key:
+        return None
+
+    if cert.exists():
+        if not key.exists():
+            print('specified cert exists but key does not: '
+                  'will not consider generation', file=sys.stderr)
+
+        return None
+
+    if not key.exists():
+        try:
+            subprocess.run(['openssl', 'genrsa', '-out', key], check=True)
+        except subprocess.CalledProcessError as exc:
+            print(f'error: openssl genrsa: exit {exc.returncode}', file=sys.stderr)
+            return exc.returncode
+
+    openssl_proc = subprocess.run([
+        'openssl', 'req', '-new', '-x509',
+        '-days', '2',
+        '-subj', '/C=XX/ST=State/L=Locality/O=Org/OU=Unit/CN=localhost/emailAddress=test@email.address',
+        '-key', key,
+        '-out', cert,
+    ])
+
+    if openssl_proc.returncode > 0:
+        print(f'error: openssl req: exit {openssl_proc.returncode}', file=sys.stderr)
+
+    return openssl_proc.returncode
+
+
+def serve(server_path='/ndt-server', *args):
+    try:
+        ndt_proc = subprocess.run([server_path] +
+                                  (list(args) if args else sys.argv[1:]))
+    except KeyboardInterrupt:
+        return 0
+    else:
+        return ndt_proc.returncode
+
+
+def main(cert, key):
+    if generation_code := generate_certificate(cert, key):
+        return generation_code
+
+    return serve()
+
+
+if __name__ == '__main__':
+    args = parse_args(make_parser())
+    returncode = main(**vars(args))
+    sys.exit(returncode)

--- a/manage/config.py
+++ b/manage/config.py
@@ -4,7 +4,7 @@ import pathlib
 BINFMT_TAG = 'a7996909642ee92942dcd6cff44b9b95f08dad64'
 BINFMT_TARGET = pathlib.Path('/proc/sys/fs/binfmt_misc/qemu-aarch64')
 
-NDT_SERVER_TAG = 'v0.20.6'
+NDT_SERVER_TAG = 'v0.20.17'
 NDT_SERVER_ORIGIN = 'm-lab/ndt-server'
 
 NETRICS_USER = 'ubuntu'


### PR DESCRIPTION
Adds to the Local Dashboard repository a `docker-compose.yml` exemplifying deployment of the dashboard, NDT server and data extraction service via Docker Compose.

This is complementary to the existing provisioning script – Compose configuration intends to achieve the same _without_ ad-hoc scripting on the host device nor any administrative control of the device.

* Compose configuration for the Local Dashboard is given; but, there are no functional changes to the Local Dashboard, (which is already deployed via Docker).
* Yet another NDT7 server Docker image is here cooked up for management by `chicagocdac` – `ndt-server-full`. This image distinguishes itself by bootstrapping its own SSL certificate as necessary, such that the container may be created and launched by Docker Compose without separate scripting on the host device – (without resorting to a much larger, development-focused image, as suggested by m-lab).
* ETL data extraction was previously handled by host-provisioned scripts launched by cron; for Compose, this is handled by an `etl` service, which runs through the default dashboard image. The emergent [scheduling library Fate](https://pypi.org/project/fate-scheduler/0.1.0rc2/) is added to the default image, along with default extraction task configuration.

Resolves #18